### PR TITLE
Fix bug with token indicators

### DIFF
--- a/about-face.js
+++ b/about-face.js
@@ -82,7 +82,7 @@ export class AboutFace
         
         TokenIndicators = [];
         for ( let [i, token] of canvas.tokens.placeables.entries()){
-            if (!(token instanceof Token)) { continue; }
+            if (!(token instanceof Token) || !token.actor) { continue; }
             //if (token.owner) {
                 // if (token.actor.isPC && game.user.isGM) {
                 //     continue;


### PR DESCRIPTION
Module calls ready when tokens have not loaded their actor object yet. By having it continue if there is no actor on the token, we prevent the module from failing early. This also allows the token indicators to actually build when the token/actor object is ready.