### PR TITLE
Fix rotation issue when deselecting a token

### DIFF
--- a/about-face.js
+++ b/about-face.js
@@ -213,6 +213,8 @@ export class AboutFace {
         let dY = (updateData.y) ? updateData.y - pos.y : 0; // new Y
         let facing = pos.facing; // facing direction
 
+        if (dX == 0 && dY == 0) return;
+
         let dir = AboutFace.getRotationDegrees(dX, dY); // new way to rotate
 
         // update our new position


### PR DESCRIPTION
Closes #22 

It seems that when you deselect a token the `updateTokenEventHandler` is called. However, since the token doesn't move when you deselect it, both the `dX` and `dY` will be 0. The `getRotationDegrees` function doesn't handle this case, so it defaults to pointing down. This is what causes the token to reset when deselecting.

So, this PR just avoids updating the token's rotation when the `dX` and `dY` are both 0.