### PR TITLE
Added support for Hex sprite on Hex Column scenes

### DIFF
--- a/src/about-face.js
+++ b/src/about-face.js
@@ -62,6 +62,21 @@ Hooks.once("init", () => {
             AboutFace.indicatorState = state;
         }
       });
+
+
+      game.settings.register(MODULE_ID, 'sprite-type', {
+        name: "about-face.options.indicator-sprite.name",
+        hint: "about-face.options.indicator-sprite.hint",
+        scope: "client",
+        config: true,
+        default: 0,
+        type: Number,
+        choices: {
+            0: "about-face.options.indicator-sprite.choices.normal",
+            1: "about-face.options.indicator-sprite.choices.large",
+            2: "about-face.options.indicator-sprite.choices.hex"
+        },
+			});
 });
 
 
@@ -132,7 +147,7 @@ export class AboutFace {
             let dX = (updateData.x != null) ? updateData.x - lastPos.x : 0; // new X
             let dY = (updateData.y != null) ? updateData.y - lastPos.y : 0; // new Y
             if (dX === 0 && dY === 0 && facing === 0) return;
-            let dir = getRotationDegrees(dX, dY);
+            let dir = getRotationDegrees(dX, dY, "", scene.data.gridType >= 4);   // Hex Columns
     
             return await token.setFlag(MODULE_ID, 'direction', dir);
         }
@@ -191,7 +206,7 @@ export class AboutFace {
     static async createTokenHandler(scene, token) {        
         token = (token instanceof Token) ? token : canvas.tokens.get(token._id);
         log(LogLevel.INFO, 'createTokenHandler, creating TokenIndicator for:', token.name);        
-        AboutFace.tokenIndicators[token.id] = await new TokenIndicator(token).create();
+        AboutFace.tokenIndicators[token.id] = await new TokenIndicator(token).create(scene);
     }
     
     static async deleteTokenHandler(scene, token) {       

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -16,5 +16,6 @@
     "about-face.options.indicator-sprite.name" : "Indicator Icon",
     "about-face.options.indicator-sprite.hint" : "Change the indicator icon (requires reload)",
     "about-face.options.indicator-sprite.choices.normal" : "Normal Indicator",
-    "about-face.options.indicator-sprite.choices.large" : "Large Indicator"
+    "about-face.options.indicator-sprite.choices.large" : "Large Indicator",
+    "about-face.options.indicator-sprite.choices.hex" : "Hex Indicator (Only works on Hex Columns)"
 }

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -19,5 +19,6 @@
     "about-face.options.indicator-sprite.name": "Tamaño del indicador",
     "about-face.options.indicator-sprite.hint": "Cambia el tamaño del indicador (requiere recargar el programa)",
     "about-face.options.indicator-sprite.choices.normal": "Normal",
-    "about-face.options.indicator-sprite.choices.large": "Grande"
+    "about-face.options.indicator-sprite.choices.large": "Grande", 
+    "about-face.options.indicator-sprite.choices.hex" : "Hex (with facings) Indicator"
 }

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -16,5 +16,6 @@
     "about-face.options.indicator-sprite.name" : "Icone Indicador",
     "about-face.options.indicator-sprite.hint" : "Mudar o icone indicador (requer reinicialização)",
     "about-face.options.indicator-sprite.choices.normal" : "Indicador Normal",
-    "about-face.options.indicator-sprite.choices.large" : "Indicador Grande"
+    "about-face.options.indicator-sprite.choices.large" : "Indicador Grande",
+    "about-face.options.indicator-sprite.choices.hex" : "Hex (with facings) Indicator"
 }

--- a/src/scripts/helpers.js
+++ b/src/scripts/helpers.js
@@ -28,16 +28,18 @@ export async function getTokenOwner(token, includeGM=false) {
  * @param {int} dY     the value of y2 - y1
  * @return int
  **/
-export function getRotationDegrees(dX = null, dY = null, dir = null) {
+export function getRotationDegrees(dX = null, dY = null, dir = null, isHexColumn = false) {
     var rotation;
+		let hexOffset = isHexColumn ? 15 : 0;
+		
     if ((dX == 0 && dY < 0) || dir == "up") rotation = 180; // up
     else if ((dX == 0 && dY > 0) || dir == "down") rotation = 0; // down
-    else if ((dX > 0 && dY == 0) || dir == "right") rotation = 270; // to the right
-    else if ((dX > 0 && dY < 0) || dir == "up-right") rotation = 225; // up to the right
-    else if ((dX > 0 && dY > 0) || dir == "down-right") rotation = 315; // down to the right
-    else if ((dX < 0 && dY == 0) || dir == "left") rotation = 90; // to the left
-    else if ((dX < 0 && dY > 0) || dir == "down-left") rotation = 45; // down to the left
-    else if ((dX < 0 && dY < 0) || dir == "up-left") rotation = 135 // up to the left
+    else if ((dX > 0 && dY == 0) || dir == "right") rotation = 270 - (hexOffset * 2); // to the right (hex columns can't go right/left)
+    else if ((dX > 0 && dY < 0) || dir == "up-right") rotation = 225 + hexOffset; // up to the right  
+    else if ((dX > 0 && dY > 0) || dir == "down-right") rotation = 315 - hexOffset; // down to the right   
+    else if ((dX < 0 && dY == 0) || dir == "left") rotation = 90 - (hexOffset * 2); // to the left      
+    else if ((dX < 0 && dY > 0) || dir == "down-left") rotation = 45 + hexOffset; // down to the left 
+    else if ((dX < 0 && dY < 0) || dir == "up-left") rotation = 135 - hexOffset; // up to the left
     let token_rotation = rotation || 0;
 
     // i messed with every version of atan, atan2 I could come up with; inverted Y makes it tough


### PR DESCRIPTION
Useful when playing on a Hex Column map, and using Hex tokens that are portraits (and not top down).   
I am working on a GURPS game system for Foundry (https://github.com/crnormand/gurps), and knowing the facings would be very useful (the front 3 in green, the "sides" in blue, and the back in red).
![image](https://user-images.githubusercontent.com/8931036/102449248-d8b7c800-4001-11eb-980a-c2e3c2fd07c3.png)

The math isn't perfect, but it is pretty close.  Unfortunately, Foundry doesn't seem to center a Hex Token in the area defined for the token, so I had to "pad" the layout to get it to look correct.  Unfortunately, it works best with 1x1 tokens.   As you increase the size of the token, it starts to get off center.  And if the token is not square, it will produce a weird outline.

I updated getRotationDegrees to report the correct rotation for Hex Column maps.    IMHO, most people use Hex Column (vs Hex Row) since the hex is horizontal on the top and bottom.

I wasn't sure where you wanted Sprite selection to be, so I put it in the default method.    
If a Hex sprite is selected, but the scene is not one of the Hex Column types, it defaults to the regular Triangle.

Sorry, I don't know Spanish or Portuguese, so I just copied the English text.




